### PR TITLE
Update header.html to fix the title navigation 

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <nav class="navigation">
   <section class="container">
-    <a class="navigation-title" href="{{ print "/" | absLangURL }}">
+    <a class="navigation-title" href="{{ print "/" | relLangURL }}">
       {{ .Site.Title }}
     </a>
     <input type="checkbox" id="menu-control"/>


### PR DESCRIPTION
Update header.html to fix the title navigation  link when using subdirectories as base url.  Fixes #2 and should fix the link that exists on the hugo demo page, yet redirects back to themes.hugo.io, not https://themes.gohugo.io/theme/hugo-coder-portfolio/.  Try the Yusuke Ishimi title button there to see what I mean.  The japanese title link is also broken. and redirects to themes.hugo.io/ja which just leads to a 404 error.