### PR TITLE
Fix absolute links to CSS files

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,11 +27,11 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
     {{ end }}
     <link  rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:400,700">
-    <link rel="stylesheet" href="{{ "css/normalize.min.css" | absURL}}">
-    <link rel="stylesheet" href="{{ "css/style.min.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/css/normalize.min.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "/css/style.min.css" | absURL }}">
 
     {{ if .Site.Params.rtl}}
-      <link rel="stylesheet" href="{{ "css/style-rtl.min.css" | absURL }}">
+      <link rel="stylesheet" href="{{ "/css/style-rtl.min.css" | absURL }}">
     {{ end }}
 
     {{ range .Site.Params.custom_css }}


### PR DESCRIPTION
Built site would break when deploying on Netlify: fixing the absolute path to the CSS files fixes the issue.